### PR TITLE
improve makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,19 @@
-docker-build:
-	TAG=$$(date +%Y%m%d%H%M%S) ;\
-	docker pull python:3.4 ; \
-	docker pull debian:stretch ; \
+docker-build-latest: docker-pull-deps
 	docker build -t ppigenpdc/foncier-app:latest . ; \
 	docker build -t ppigenpdc/foncier-worker:latest celery ; \
-	#~ docker build -t ppigenpdc/foncier-app:$$TAG . ; \
-	#~ docker build -t ppigenpdc/foncier-worker:$$TAG celery ; \
-	#~ docker push ppigenpdc/foncier-app:$$TAG ; \
-	#~ docker push ppigenpdc/foncier-app:latest ; \
-	#~ docker push ppigenpdc/foncier-worker:$$TAG ; \
-	#~ docker push ppigenpdc/foncier-worker:latest ; \
+
+docker-build-push: docker-build-latest
+	TAG=$$(date +%Y%m%d%H%M%S) ;\
+	docker tag ppigenpdc/foncier-app:latest ppigenpdc/foncier-app:$$TAG ; \
+	docker tag ppigenpdc/foncier-worker:latest ppigenpdc/foncier-worker:$$TAG ; \
+	docker push ppigenpdc/foncier-app:$$TAG ; \
+	docker push ppigenpdc/foncier-app:latest ; \
+	docker push ppigenpdc/foncier-worker:$$TAG ; \
+	docker push ppigenpdc/foncier-worker:latest ; \
+
+docker-pull-deps:
+	docker pull python:3.4 ; \
+	docker pull debian:stretch ; \
 
 docker-stop-rm:
 	docker-compose stop
@@ -24,4 +28,4 @@ docker-clean-images:
 docker-clean-all:
 	docker-compose down --volumes --rmi 'all' --remove-orphans
 
-all: docker-build
+all: docker-build-latest


### PR DESCRIPTION
By default, `make` invokes `docker-build-latest`, which pulls deps and builds `latest` images.
This is useful for dev.

`make docker-build-push` will do the same, but also tags the images with a timestamp and pushes to the repository. This is useful when the dev is over, and images are ready for production.